### PR TITLE
VoxelNiagara: Fix crash in Getters

### DIFF
--- a/Source/VoxelNiagara/Private/NiagaraDataInterfaceVoxelDataAsset.cpp
+++ b/Source/VoxelNiagara/Private/NiagaraDataInterfaceVoxelDataAsset.cpp
@@ -172,10 +172,10 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetVMExternalFunction(const FVMExterna
 
 void UNiagaraDataInterfaceVoxelDataAsset::GetAssetValue(FVectorVMContext& Context)
 {
+	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncInputHandler<float> XParam(Context);
 	VectorVM::FExternalFuncInputHandler<float> YParam(Context);
 	VectorVM::FExternalFuncInputHandler<float> ZParam(Context);
-	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutValue(Context);
 
 	auto& Data = *InstData->Data;
@@ -190,10 +190,10 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetAssetValue(FVectorVMContext& Contex
 
 void UNiagaraDataInterfaceVoxelDataAsset::GetAssetColor(FVectorVMContext& Context)
 {
+	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncInputHandler<float> XParam(Context);
 	VectorVM::FExternalFuncInputHandler<float> YParam(Context);
 	VectorVM::FExternalFuncInputHandler<float> ZParam(Context);
-	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutR(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutG(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutB(Context);
@@ -215,9 +215,8 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetAssetColor(FVectorVMContext& Contex
 
 void UNiagaraDataInterfaceVoxelDataAsset::GetPositionFromAsset(FVectorVMContext& Context)
 {
-	VectorVM::FExternalFuncInputHandler<int32> IndexParam(Context);
 	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
-
+	VectorVM::FExternalFuncInputHandler<int32> IndexParam(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutX(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutY(Context);
 	VectorVM::FExternalFuncRegisterHandler<float> OutZ(Context);


### PR DESCRIPTION
*Crash in Unreal Engine 4.25*
![image](https://user-images.githubusercontent.com/446619/84418845-087fb080-ac18-11ea-967d-db662001b22f.png)

Seems like `FUserPtrHandler` has to come before any `FExternalFunc*Handler`.

*What has been fixed*

Fixed methods: GetPositionFromAsset, GetAssetColor, GetAssetValue.

*Do you agree to give away all your rights on this PR?*
Yes I do!

*But does it work now?*
Yes! No unit tests though, I hope a screenshot showing that it works is enough. ;)

![image](https://user-images.githubusercontent.com/446619/84420347-3239d700-ac1a-11ea-89bd-5b5d0c36c4ac.png)
![image](https://user-images.githubusercontent.com/446619/84420549-7b8a2680-ac1a-11ea-93b6-a422f007af19.png)
