### PR TITLE
Fix Build on UE 5.0.3

### DIFF
--- a/Source/Voxel/Private/VoxelDebug/VoxelLineBatchComponent.cpp
+++ b/Source/Voxel/Private/VoxelDebug/VoxelLineBatchComponent.cpp
@@ -267,7 +267,13 @@ void FVoxelLineBatcherSceneProxy::GetDynamicMeshElements(const TArray<const FSce
 
 				for (int32 VertIdx = 0; VertIdx < Mesh.MeshVerts.Num(); ++VertIdx)
 				{
-					MeshBuilder.AddVertex(Mesh.MeshVerts[VertIdx], FVector2D::ZeroVector, PosX, PosY, PosZ, FColor::White);
+					MeshBuilder.AddVertex(
+						UE_5_CONVERT(FVector3f, Mesh.MeshVerts[VertIdx]),
+						UE_5_SWITCH(FVector2D::ZeroVector, FVector2f::ZeroVector),
+						UE_5_CONVERT(FVector3f, PosX),
+						UE_5_CONVERT(FVector3f, PosY),
+						UE_5_CONVERT(FVector3f, PosZ),
+						FColor::White);
 				}
 				for (int32 Idx = 0; Idx < Mesh.MeshIndices.Num(); Idx += 3)
 				{

--- a/Source/Voxel/Private/VoxelImporters/VoxelMeshImporter.cpp
+++ b/Source/Voxel/Private/VoxelImporters/VoxelMeshImporter.cpp
@@ -53,7 +53,7 @@ static void GetMergedSectionFromStaticMesh(
 			Vertices.SetNumUninitialized(PositionVertexBuffer.GetNumVertices());
 			for (uint32 Index = 0; Index < PositionVertexBuffer.GetNumVertices(); Index++)
 			{
-				Get(Vertices, Index) = PositionVertexBuffer.VertexPosition(Index);
+				Get(Vertices, Index) = UE_5_CONVERT(FVector, PositionVertexBuffer.VertexPosition(Index));
 			}
 		}
 		{
@@ -70,7 +70,7 @@ static void GetMergedSectionFromStaticMesh(
 			UVs.SetNumUninitialized(StaticMeshVertexBuffer.GetNumVertices());
 			for (uint32 Index = 0; Index < StaticMeshVertexBuffer.GetNumVertices(); Index++)
 			{
-				Get(UVs, Index) = StaticMeshVertexBuffer.GetVertexUV(Index, 0);
+				Get(UVs, Index) = UE_5_CONVERT(FVector2D, StaticMeshVertexBuffer.GetVertexUV(Index, 0));
 			}
 		}
 	}

--- a/Source/Voxel/Private/VoxelRender/MaterialCollections/VoxelLandscapeMaterialCollection.cpp
+++ b/Source/Voxel/Private/VoxelRender/MaterialCollections/VoxelLandscapeMaterialCollection.cpp
@@ -308,9 +308,9 @@ UMaterialInstanceConstant* UVoxelLandscapeMaterialCollection::CreateInstanceForP
 			AddedLayers.Add(Name);
 
 			FStaticTerrainLayerWeightParameter Parameter;
-			Parameter.ParameterInfo = NameToInfo[Name].Info;
-			Parameter.bOverride = true;
-			Parameter.ExpressionGUID = NameToInfo[Name].Guid;
+			Parameter.UE_5_SWITCH(ParameterInfo, ParameterInfo_DEPRECATED) = NameToInfo[Name].Info;
+			Parameter.UE_5_SWITCH(bOverride, bOverride_DEPRECATED) = true;
+			Parameter.UE_5_SWITCH(ExpressionGUID, ExpressionGUID_DEPRECATED) = NameToInfo[Name].Guid;
 			// Pass the layer to use to the voxel expression
 			// Add 1 000 000 to detect voxel vs landscape indices
 			Parameter.WeightmapIndex = 1000000 + Index;
@@ -329,9 +329,9 @@ UMaterialInstanceConstant* UVoxelLandscapeMaterialCollection::CreateInstanceForP
 			}
 			
 			FStaticTerrainLayerWeightParameter Parameter;
-			Parameter.ParameterInfo = NameToInfo[Layer.Name].Info;
-			Parameter.bOverride = true;
-			Parameter.ExpressionGUID = NameToInfo[Layer.Name].Guid;
+			Parameter.UE_5_SWITCH(ParameterInfo, ParameterInfo_DEPRECATED) = NameToInfo[Layer.Name].Info;
+			Parameter.UE_5_SWITCH(bOverride, bOverride_DEPRECATED) = true;
+			Parameter.UE_5_SWITCH(ExpressionGUID, ExpressionGUID_DEPRECATED) = NameToInfo[Layer.Name].Guid;
 			// 1 000 006 is used to set Default
 			Parameter.WeightmapIndex = 1000006;
 			StaticParameters.TerrainLayerWeightParameters.Add(Parameter);
@@ -365,12 +365,20 @@ void UVoxelLandscapeMaterialCollection::ForeachMaterialParameter(TFunctionRef<vo
 	TArray<FMaterialParameterInfo> ParameterInfos;
 	TArray<FGuid> Guids;
 
+#if VOXEL_ENGINE_VERSION < 500
 	ActualMaterial->GetAllParameterInfo<UMaterialExpressionLandscapeLayerWeight>(ParameterInfos, Guids);
 	ActualMaterial->GetAllParameterInfo<UMaterialExpressionLandscapeLayerSwitch>(ParameterInfos, Guids);
 	ActualMaterial->GetAllParameterInfo<UMaterialExpressionLandscapeLayerSample>(ParameterInfos, Guids);
 	ActualMaterial->GetAllParameterInfo<UMaterialExpressionLandscapeLayerBlend>(ParameterInfos, Guids);
 	// Note: don't query landscape visibility parameter name, it just returns __LANDSCAPE_VISIBILITY__
-	
+#else
+	for (int32 ParameterTypeIndex = 0; ParameterTypeIndex < NumMaterialParameterTypes; ++ParameterTypeIndex)
+	{
+		const EMaterialParameterType ParameterType = static_cast<EMaterialParameterType>(ParameterTypeIndex);
+		ActualMaterial->GetAllParameterInfoOfType(ParameterType, ParameterInfos, Guids);
+	}
+#endif
+
 	if (!ensure(ParameterInfos.Num() == Guids.Num()))
 	{
 		return;

--- a/Source/Voxel/Private/VoxelRender/PhysicsCooker/VoxelAsyncPhysicsCooker_Chaos.cpp
+++ b/Source/Voxel/Private/VoxelRender/PhysicsCooker/VoxelAsyncPhysicsCooker_Chaos.cpp
@@ -70,7 +70,7 @@ void FVoxelAsyncPhysicsCooker_Chaos::CreateTriMesh()
 
 	const auto Process = [&](auto& Triangles)
 	{
-		Chaos::TParticles<Chaos::FReal, 3> Particles;
+		Chaos::FTriangleMeshImplicitObject::ParticlesType Particles;
 
 		{
 			VOXEL_ASYNC_SCOPE_COUNTER("Copy data from buffers");
@@ -152,12 +152,12 @@ void FVoxelAsyncPhysicsCooker_Chaos::CreateTriMesh()
 	
 	if (NumVertices < TNumericLimits<uint16>::Max())
 	{
-		TArray<Chaos::TVector<uint16, 3>> TrianglesSmallIdx;
+		TArray<Chaos::TVec3<uint16>> TrianglesSmallIdx;
 		Process(TrianglesSmallIdx);
 	}
 	else
 	{
-		TArray<Chaos::TVector<int32, 3>> TrianglesLargeIdx;
+		TArray<Chaos::TVec3<int32>> TrianglesLargeIdx;
 		Process(TrianglesLargeIdx);
 	}
 }

--- a/Source/Voxel/Private/VoxelRender/VoxelMaterialExpressions.cpp
+++ b/Source/Voxel/Private/VoxelRender/VoxelMaterialExpressions.cpp
@@ -63,7 +63,7 @@ public:
 			{
 				VoxelIndices.Add(WeightmapIndex);
 				
-				if (Parameter.ParameterInfo.Name == ParameterName)
+				if (Parameter.UE_5_SWITCH(ParameterInfo.Name, ParameterInfo_DEPRECATED.Name) == ParameterName)
 				{
 					ParameterVoxelIndex = WeightmapIndex;
 				}
@@ -167,7 +167,7 @@ public:
 		return Compiler->MaterialBakingWorldPosition();
 	}
 
-#if VOXEL_ENGINE_VERSION >= 426
+#if VOXEL_ENGINE_VERSION >= 426 && VOXEL_ENGINE_VERSION < 500
 	virtual int32 PreSkinVertexOffset() override
 	{
 		return Compiler->PreSkinVertexOffset();

--- a/Source/Voxel/Private/VoxelRender/VoxelProceduralMeshComponent.cpp
+++ b/Source/Voxel/Private/VoxelRender/VoxelProceduralMeshComponent.cpp
@@ -674,7 +674,7 @@ bool UVoxelProceduralMeshComponent::DoCustomNavigableGeometryExport(FNavigableGe
 				Vertices.SetNumUninitialized(PositionBuffer.GetNumVertices());
 				for (int32 Index = 0; Index < Vertices.Num(); Index++)
 				{
-					Vertices[Index] = PositionBuffer.VertexPosition(Index);
+					Vertices[Index] = UE_5_CONVERT(FVector, PositionBuffer.VertexPosition(Index));
 				}
 			}
 			TArray<int32> Indices;

--- a/Source/Voxel/Private/VoxelRender/VoxelProceduralMeshSceneProxy.cpp
+++ b/Source/Voxel/Private/VoxelRender/VoxelProceduralMeshSceneProxy.cpp
@@ -630,7 +630,7 @@ void FVoxelProceduralMeshSceneProxy::GetDynamicRayTracingInstances(FRayTracingMa
 
 				RayTracingInstance.Materials.Add(MeshBatch);
 
-				RayTracingInstance.BuildInstanceMaskAndFlags();
+				RayTracingInstance.BuildInstanceMaskAndFlags(UE_5_ONLY(ERHIFeatureLevel::Type::SM6));
 				OutRayTracingInstances.Add(RayTracingInstance);
 			}
 		}

--- a/Source/Voxel/Private/VoxelRender/VoxelRenderUtilities.cpp
+++ b/Source/Voxel/Private/VoxelRender/VoxelRenderUtilities.cpp
@@ -277,7 +277,8 @@ TUniquePtr<FVoxelProcMeshBuffers> FVoxelRenderUtilities::MergeSections_AnyThread
 		const int32 ChunkNumVertices = Chunk.GetNumVertices();
 		for (int32 Index = 0; Index < ChunkNumVertices; Index++)
 		{
-			PositionBuffer.VertexPosition(VerticesOffset + Index) = FVoxelUtilities::Get(Chunk.Positions, Index) + Offset;
+			const auto NewPos = FVoxelUtilities::Get(Chunk.Positions, Index) + Offset;
+			PositionBuffer.VertexPosition(VerticesOffset + Index) = UE_5_CONVERT(FVector3f, NewPos);
 		}
 	};
 	const auto CopyColorsAndTextureData = [&](const FVoxelChunkMeshBuffers& Chunk)
@@ -334,13 +335,17 @@ TUniquePtr<FVoxelProcMeshBuffers> FVoxelRenderUtilities::MergeSections_AnyThread
 			{
 				auto& Tangent = FVoxelUtilities::Get(Chunk.Tangents, Index);
 				auto& Normal = FVoxelUtilities::Get(Chunk.Normals, Index);
-				StaticMeshBuffer.SetVertexTangents(VerticesOffset + Index, Tangent.TangentX, Tangent.GetY(Normal), Normal);
+				StaticMeshBuffer.SetVertexTangents(
+					VerticesOffset + Index,
+					UE_5_CONVERT(FVector3f, Tangent.TangentX),
+					UE_5_CONVERT(FVector3f, Tangent.GetY(Normal)),
+					UE_5_CONVERT(FVector3f, Normal));
 			}
 			check(Chunk.TextureCoordinates.Num() == NumTextureCoordinates);
 			for (int32 Tex = 0; Tex < NumTextureCoordinates; Tex++)
 			{
 				auto& TextureCoordinate = FVoxelUtilities::Get(Chunk.TextureCoordinates[Tex], Index);
-				StaticMeshBuffer.SetVertexUV(VerticesOffset + Index, Tex, TextureCoordinate);
+				StaticMeshBuffer.SetVertexUV(VerticesOffset + Index, Tex, UE_5_CONVERT(FVector2f, TextureCoordinate));
 			}
 		}
 	};
@@ -393,11 +398,12 @@ TUniquePtr<FVoxelProcMeshBuffers> FVoxelRenderUtilities::MergeSections_AnyThread
 				VOXEL_ASYNC_SCOPE_COUNTER("TranslateVertices");
 				for (int32 Index = 0; Index < MainChunk.GetNumVertices(); Index++)
 				{
-					PositionBuffer.VertexPosition(VerticesOffset + Index) = FVoxelMesherUtilities::GetTranslatedTransvoxel(
+					const auto NewPos = FVoxelMesherUtilities::GetTranslatedTransvoxel(
 						FVoxelUtilities::Get(MainChunk.Positions, Index),
 						FVoxelUtilities::Get(MainChunk.Normals, Index),
 						Chunk.TransitionsMask,
 						Chunk.LOD) + PositionOffset;
+					PositionBuffer.VertexPosition(VerticesOffset + Index) = UE_5_CONVERT(FVector3f, NewPos);
 				}
 			}
 			else

--- a/Source/Voxel/Private/VoxelShaders/VoxelErosion.cpp
+++ b/Source/Voxel/Private/VoxelShaders/VoxelErosion.cpp
@@ -173,7 +173,7 @@ void UVoxelErosion::CopyTextureToRHI(const TVoxelTexture<float>& Texture, const 
 		ThisPtr->CopyTextureToRHI_RenderThread(Texture, RHITexture);
 	});
 
-	FlushRenderingCommands(false);
+	FlushRenderingCommands(UE_5_SWITCH(false,));
 }
 
 void UVoxelErosion::CopyRHIToTexture(const FTexture2DRHIRef& RHITexture, TVoxelSharedRef<TVoxelTexture<float>::FTextureData>& Texture)
@@ -184,7 +184,7 @@ void UVoxelErosion::CopyRHIToTexture(const FTexture2DRHIRef& RHITexture, TVoxelS
 		ThisPtr->CopyRHIToTexture_RenderThread(RHITexture, *Texture);
 	});
 
-	FlushRenderingCommands(false);
+	FlushRenderingCommands(UE_5_SWITCH(false,));
 }
 
 void UVoxelErosion::CopyTextureToRHI_RenderThread(const TVoxelTexture<float>& Texture, const FTexture2DRHIRef& RHITexture)

--- a/Source/Voxel/Private/VoxelStaticWorld.cpp
+++ b/Source/Voxel/Private/VoxelStaticWorld.cpp
@@ -19,7 +19,7 @@ void AVoxelStaticWorld::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
 	{
 		for (auto* Mesh : Meshes)
 		{
-			auto* StaticMesh = Mesh->GetStaticMesh();
+			UE_5_SWITCH(auto*, auto) StaticMesh = Mesh->GetStaticMesh();
 			auto RelativeTransform = Mesh->GetRelativeTransform();
 			Mesh->ReinitializeProperties(BaseMesh);
 			Mesh->AttachToComponent(RootComponent, FAttachmentTransformRules::KeepWorldTransform);

--- a/Source/Voxel/Public/VoxelContainers/NoGrowArray.h
+++ b/Source/Voxel/Public/VoxelContainers/NoGrowArray.h
@@ -22,13 +22,14 @@ public:
 	};
 
 	template<typename ElementType>
-	class ForElementType : public T::template ForAnyElementType<ElementType>
+	class ForElementType 
+		UE_5_SWITCH( : public T::template ForAnyElementType<ElementType>, : public T::template ForAnyElementType)
 	{
 	public:
 		FORCEINLINE typename T::SizeType CalculateSlackGrow(typename T::SizeType NumElements, typename T::SizeType NumAllocatedElements, SIZE_T NumBytesPerElement) const
 		{
 			ensure(false);
-			return T::template ForAnyElementType<ElementType>::CalculateSlackGrow(NumElements, NumAllocatedElements, NumBytesPerElement);
+			return UE_5_SWITCH(T::template ForAnyElementType<ElementType>, T::template ForAnyElementType)::CalculateSlackGrow(NumElements, NumAllocatedElements, NumBytesPerElement);
 		}
 	};
 };

--- a/Source/Voxel/Public/VoxelEngineVersionHelpers.h
+++ b/Source/Voxel/Public/VoxelEngineVersionHelpers.h
@@ -53,9 +53,11 @@
 #if VOXEL_ENGINE_VERSION >= 500
 #define UE_5_SWITCH(Before, AfterOrEqual) AfterOrEqual
 #define UE_5_ONLY(...) __VA_ARGS__
+#define UE_5_CONVERT(Type, ...) Type(__VA_ARGS__)
 #else
 #define UE_5_SWITCH(Before, AfterOrEqual) Before
 #define UE_5_ONLY(...)
+#define UE_5_CONVERT(Type, ...) __VA_ARGS__
 #endif
 
 #if VOXEL_ENGINE_VERSION < 425

--- a/Source/Voxel/Public/VoxelSharedPtr.h
+++ b/Source/Voxel/Public/VoxelSharedPtr.h
@@ -31,7 +31,7 @@ inline TVoxelWeakPtr<T> MakeVoxelWeakPtr(T* Ptr)
 }
 
 template<typename T, template<class, ESPMode> class TPtr>
-inline TWeakPtr<T> MakeWeakPtr(const TPtr<T, ESPMode::Fast>& Ptr)
+inline TWeakPtr<T> MakeWeakPtr(const TPtr<T, UE_5_SWITCH(ESPMode::Fast, ESPMode::ThreadSafe)>& Ptr)
 {
 	return TWeakPtr<T>(Ptr);
 }

--- a/Source/Voxel/Public/VoxelUtilities/VoxelMathUtilities.h
+++ b/Source/Voxel/Public/VoxelUtilities/VoxelMathUtilities.h
@@ -474,7 +474,7 @@ namespace FVoxelUtilities
 	FORCEINLINE float SmoothFalloff(float Distance, float Radius, float Falloff)
 	{
 		const float X = LinearFalloff(Distance, Radius, Falloff);
-		return FMath::SmoothStep(0, 1, X);
+		return FMath::SmoothStep(0.f, 1.f, X);
 	}
 	FORCEINLINE float SphericalFalloff(float Distance, float Radius, float Falloff)
 	{

--- a/Source/Voxel/Public/VoxelUtilities/VoxelStatsUtilities.h
+++ b/Source/Voxel/Public/VoxelUtilities/VoxelStatsUtilities.h
@@ -28,7 +28,7 @@ namespace FVoxelUtilities
 	};
 
 #define VOXEL_SCOPE_COUNTER_FORMAT(Format, ...) \
-	FCpuProfilerTrace::FEventScope PREPROCESSOR_JOIN(CpuProfilerEventScope, __LINE__)(FVoxelUtilities::GetStatsIdFromStringFormat([](){}, TEXT(Format), ##__VA_ARGS__) ONLY_UE_25_AND_HIGHER(, CpuChannel));
+	FCpuProfilerTrace::FEventScope PREPROCESSOR_JOIN(CpuProfilerEventScope, __LINE__)(FVoxelUtilities::GetStatsIdFromStringFormat([](){}, TEXT(Format), ##__VA_ARGS__) ONLY_UE_25_AND_HIGHER(, CpuChannel) UE_5_ONLY(, true));
 #else
 #define VOXEL_SCOPE_COUNTER_FORMAT(Format, ...) VOXEL_ASYNC_SCOPE_COUNTER(Format)
 #endif

--- a/Source/VoxelEditor/Private/VoxelEditorToolsPanel.cpp
+++ b/Source/VoxelEditor/Private/VoxelEditorToolsPanel.cpp
@@ -374,6 +374,11 @@ void FVoxelEditorToolsPanel::CustomizeToolbar(FToolBarBuilder& ToolBarBuilder)
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
 
+FString FVoxelEditorToolsPanel::GetReferencerName() const
+{
+	return TEXT("FVoxelEditorToolsPanel");;
+}
+
 void FVoxelEditorToolsPanel::AddReferencedObjects(FReferenceCollector& Collector)
 {
 	Collector.AddReferencedObject(ToolManager);

--- a/Source/VoxelEditor/Private/VoxelEditorToolsPanel.cpp
+++ b/Source/VoxelEditor/Private/VoxelEditorToolsPanel.cpp
@@ -229,7 +229,7 @@ void FVoxelEditorToolsPanel::Init(const TSharedPtr<FUICommandList>& CommandListO
 	.AutoHeight()
 	[
 		SNew(SBorder)
-		.BorderImage(FEditorStyle::GetBrush("DetailsView.AdvancedDropdownBorder"))
+		UE_5_SWITCH(.BorderImage(FEditorStyle::GetBrush("DetailsView.AdvancedDropdownBorder")),)
 		.Padding(FMargin(0.0f, 3.0f, 16.f, 0.0f))
 		[
 			SAssignNew(ExpanderButton, SButton)
@@ -263,6 +263,7 @@ void FVoxelEditorToolsPanel::Init(const TSharedPtr<FUICommandList>& CommandListO
 		]
 	];
 
+#if VOXEL_ENGINE_VERSION < 500
 	CustomToolBarsVerticalBox->AddSlot()
 	.AutoHeight()
 	[
@@ -274,6 +275,7 @@ void FVoxelEditorToolsPanel::Init(const TSharedPtr<FUICommandList>& CommandListO
 			.Image(FEditorStyle::GetBrush("DetailsView.AdvancedDropdownBorder.Open"))
 		]
 	];
+#endif
 	
 	for (auto& ToolBarBuilder : CustomToolBarBuilders)
 	{
@@ -320,7 +322,7 @@ void FVoxelEditorToolsPanel::CustomizeToolbar(FToolBarBuilder& ToolBarBuilder)
 {
 	const auto& Commands = FVoxelToolsCommands::Get();
 	
-#if VOXEL_ENGINE_VERSION  >= 425
+#if VOXEL_ENGINE_VERSION  >= 425 && VOXEL_ENGINE_VERSION < 500
 	ToolBarBuilder.AddToolBarButton(Commands.SurfaceTool);
 	ToolBarBuilder.AddToolBarButton(Commands.SmoothTool);
 	ToolBarBuilder.AddToolBarButton(Commands.MeshTool);

--- a/Source/VoxelEditor/Private/VoxelEditorToolsPanel.h
+++ b/Source/VoxelEditor/Private/VoxelEditorToolsPanel.h
@@ -37,6 +37,7 @@ public:
 
 public:
 	//~ Begin FGCObject Interface
+	virtual FString GetReferencerName() const override;
 	virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 	//~ End FGCObject Interface
 

--- a/Source/VoxelGraph/Public/NodeFunctions/VoxelNodeFunctions.h
+++ b/Source/VoxelGraph/Public/NodeFunctions/VoxelNodeFunctions.h
@@ -890,7 +890,7 @@ namespace FVoxelNodeFunctions
 		if (Context.bHasCustomTransform)
 		{
 			const FVector Scale = Context.LocalToWorld.GetScale3D();
-			const TVoxelRange<v_flt> ScaleRange{ Scale.GetMin(), Scale.GetMax() };
+			const TVoxelRange<v_flt> ScaleRange{ static_cast<v_flt>(Scale.GetMin()), static_cast<v_flt>(Scale.GetMax()) };
 			const auto Result = TVoxelRange<v_flt>::Union(InX * ScaleRange, InY * ScaleRange, InZ * ScaleRange);
 			
 			OutX = Result;
@@ -911,7 +911,7 @@ namespace FVoxelNodeFunctions
 		if (Context.bHasCustomTransform)
 		{
 			const FVector Scale = FVector(1.f) / Context.LocalToWorld.GetScale3D();
-			const TVoxelRange<v_flt> ScaleRange{ Scale.GetMin(), Scale.GetMax() };
+			const TVoxelRange<v_flt> ScaleRange{ static_cast<v_flt>(Scale.GetMin()), static_cast<v_flt>(Scale.GetMax()) };
 			const auto Result = TVoxelRange<v_flt>::Union(InX * ScaleRange, InY * ScaleRange, InZ * ScaleRange);
 			
 			OutX = Result;

--- a/Source/VoxelGraphEditor/Private/Preview/SVoxelGraphPreview.cpp
+++ b/Source/VoxelGraphEditor/Private/Preview/SVoxelGraphPreview.cpp
@@ -120,7 +120,7 @@ FReply SVoxelGraphPreview::OnMouseButtonDown(const FGeometry& MyGeometry, const 
 		const FVector2D RelativePosition = LocalClickPosition / Size;
 
 		const FVoxelGraphPreviewSettingsWrapper Wrapper(*PreviewSettings);
-		PreviewSettings->PreviewedVoxel = Wrapper.Start + FVoxelUtilities::RoundToInt(Wrapper.GetRelativePosition(RelativePosition.X, 1 - RelativePosition.Y) * FVector(Wrapper.Size * Wrapper.Step));
+		PreviewSettings->PreviewedVoxel = Wrapper.Start + FVoxelUtilities::RoundToInt(Wrapper.GetRelativePosition(static_cast<float>(RelativePosition.X), 1.f - RelativePosition.Y) * FVector(Wrapper.Size * Wrapper.Step));
 
 		if (!PreviewSettings->bShowStats && !PreviewSettings->bShowValues)
 		{
@@ -147,7 +147,7 @@ FReply SVoxelGraphPreview::OnMouseButtonUp(const FGeometry& MyGeometry, const FP
 		const FVector2D RelativePosition = Position / Size;
 		
 		const FVoxelGraphPreviewSettingsWrapper Wrapper(*PreviewSettings);
-		PreviewSettings->Center -= FVoxelUtilities::RoundToInt(Wrapper.GetRelativePosition(RelativePosition.X, -RelativePosition.Y) * FVector(Wrapper.Size * Wrapper.Step));
+		PreviewSettings->Center -= FVoxelUtilities::RoundToInt(Wrapper.GetRelativePosition(static_cast<float>(RelativePosition.X), static_cast<float>(- RelativePosition.Y)) * FVector(Wrapper.Size * Wrapper.Step));
 
 		FPropertyChangedEvent PropertyChangedEvent(UVoxelGraphPreviewSettings::StaticClass()->FindPropertyByName(GET_MEMBER_NAME_CHECKED(UVoxelGraphPreviewSettings, Center)));
 		PreviewSettings->PostEditChangeProperty(PropertyChangedEvent);

--- a/Source/VoxelGraphEditor/Private/VoxelGraphNodes/VoxelGraphNode.cpp
+++ b/Source/VoxelGraphEditor/Private/VoxelGraphNodes/VoxelGraphNode.cpp
@@ -100,7 +100,7 @@ void UVoxelGraphNode::RemoveInputPin(UEdGraphPin* InGraphPin)
 	{
 		if (InGraphPin == InputPin)
 		{
-			InGraphPin->MarkPendingKill();
+			InGraphPin->UE_5_SWITCH(MarkPendingKill(), MarkAsGarbage());
 			Pins.Remove(InGraphPin);
 
 			const int32 Increment = VoxelNode->GetInputPinsIncrement();

--- a/Source/VoxelNiagara/Private/NiagaraDataInterfaceVoxelDataAsset.cpp
+++ b/Source/VoxelNiagara/Private/NiagaraDataInterfaceVoxelDataAsset.cpp
@@ -171,7 +171,7 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetVMExternalFunction(const FVMExterna
 	}
 }
 
-void UNiagaraDataInterfaceVoxelDataAsset::GetAssetValue(FVectorVMContext& Context)
+void UNiagaraDataInterfaceVoxelDataAsset::GetAssetValue(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context)
 {
 	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncInputHandler<float> XParam(Context);
@@ -180,7 +180,7 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetAssetValue(FVectorVMContext& Contex
 	VectorVM::FExternalFuncRegisterHandler<float> OutValue(Context);
 
 	auto& Data = *InstData->Data;
-	for (int32 i = 0; i < Context.NumInstances; ++i)
+	for (int32 i = 0; i < Context.UE_5_SWITCH(NumInstances, GetNumInstances()); ++i)
 	{
 		const float X = XParam.GetAndAdvance();
 		const float Y = YParam.GetAndAdvance();
@@ -189,7 +189,7 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetAssetValue(FVectorVMContext& Contex
 	}
 }
 
-void UNiagaraDataInterfaceVoxelDataAsset::GetAssetColor(FVectorVMContext& Context)
+void UNiagaraDataInterfaceVoxelDataAsset::GetAssetColor(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context)
 {
 	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncInputHandler<float> XParam(Context);
@@ -201,7 +201,7 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetAssetColor(FVectorVMContext& Contex
 	VectorVM::FExternalFuncRegisterHandler<float> OutA(Context);
 
 	auto& Data = *InstData->Data;
-	for (int32 i = 0; i < Context.NumInstances; ++i)
+	for (int32 i = 0; i < Context.UE_5_SWITCH(NumInstances, GetNumInstances()); ++i)
 	{
 		const float X = XParam.GetAndAdvance();
 		const float Y = YParam.GetAndAdvance();
@@ -214,7 +214,7 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetAssetColor(FVectorVMContext& Contex
 	}
 }
 
-void UNiagaraDataInterfaceVoxelDataAsset::GetPositionFromAsset(FVectorVMContext& Context)
+void UNiagaraDataInterfaceVoxelDataAsset::GetPositionFromAsset(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context)
 {
 	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncInputHandler<int32> IndexParam(Context);
@@ -223,7 +223,7 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetPositionFromAsset(FVectorVMContext&
 	VectorVM::FExternalFuncRegisterHandler<float> OutZ(Context);
 
 	auto& Positions = InstData->Positions;
-	for (int32 i = 0; i < Context.NumInstances; ++i)
+	for (int32 i = 0; i < Context.UE_5_SWITCH(NumInstances, GetNumInstances()); ++i)
 	{
 		const int32 Index = IndexParam.GetAndAdvance();
 		FVector Position(0, 0, 0);
@@ -237,13 +237,13 @@ void UNiagaraDataInterfaceVoxelDataAsset::GetPositionFromAsset(FVectorVMContext&
 	}
 }
 
-void UNiagaraDataInterfaceVoxelDataAsset::GetNumVoxels(FVectorVMContext& Context)
+void UNiagaraDataInterfaceVoxelDataAsset::GetNumVoxels(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context)
 {
 	VectorVM::FUserPtrHandler<FNDIVoxelDataAsset_InstanceData> InstData(Context);
 	VectorVM::FExternalFuncRegisterHandler<int32> OutNum(Context);
 
 	const int32 Num = InstData->Positions.Num();
-	for (int32 i = 0; i < Context.NumInstances; ++i)
+	for (int32 i = 0; i < Context.UE_5_SWITCH(NumInstances, GetNumInstances()); ++i)
 	{
 		*OutNum.GetDestAndAdvance() = Num;
 	}

--- a/Source/VoxelNiagara/Public/NiagaraDataInterfaceVoxelDataAsset.h
+++ b/Source/VoxelNiagara/Public/NiagaraDataInterfaceVoxelDataAsset.h
@@ -44,10 +44,10 @@ public:
 	virtual bool CanExecuteOnTarget(ENiagaraSimTarget Target) const override { return Target == ENiagaraSimTarget::CPUSim; }
 	//UNiagaraDataInterface Interface End
 
-	static void GetAssetValue(FVectorVMContext& Context);
-	static void GetAssetColor(FVectorVMContext& Context);
-	static void GetPositionFromAsset(FVectorVMContext& Context);
-	static void GetNumVoxels(FVectorVMContext& Context);
+	static void GetAssetValue(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context);
+	static void GetAssetColor(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context);
+	static void GetPositionFromAsset(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context);
+	static void GetNumVoxels(UE_5_SWITCH(FVectorVMContext, FVectorVMExternalFunctionContext)& Context);
 
 	virtual bool Equals(const UNiagaraDataInterface* Other) const override;
 protected:

--- a/Source/VoxelVDB/VoxelVDB.Build.cs
+++ b/Source/VoxelVDB/VoxelVDB.Build.cs
@@ -6,7 +6,7 @@ using UnrealBuildTool;
 public class VoxelVDB : ModuleRules
 {
     public VoxelVDB(ReadOnlyTargetRules Target) : base(Target)
-{
+    {
         // OpenVDB/boost requires to have both of these on
         // RTTI is a global setting in packaged games: as such, this module is editor only by default
         // Set it to Runtime in Voxel.uplugin if you wish to use VDB at runtime
@@ -35,5 +35,10 @@ public class VoxelVDB : ModuleRules
                 "Engine"
             }
         );
+
+#if UE_5_0_OR_LATER
+        // Needed to use OpenVDB, else include problems from it
+        AddEngineThirdPartyPrivateStaticDependencies(Target, "IntelTBB");
+#endif
     }
 }


### PR DESCRIPTION
I have heard that an update is coming, yet it was a fun exercise to do. I hope it will help some people who want to get started with the pluggin on UE5 in the meantime 😁

## What does this PR do?

fix https://github.com/Phyronnaz/VoxelPlugin/issues/441, fix https://github.com/Phyronnaz/VoxelPlugin/issues/440, and maybe https://github.com/Phyronnaz/VoxelPlugin/issues/439

Added the macro `UE_5_CONVERT` in `VoxelEngineVersionHelpers.h` to convert some data types to the API changes (it has a cost because we are making a new object on the stack, not casting).

Used the macro `UE_5_SWITCH` on several places to adapt to the API changes (when needed, used a check against `VOXEL_ENGINE_VERSION`). As some variables are now postfixed as DEPRECATED some places will need bigger revamps in the near future.

Hide minor textures in UE5 from the Voxel details panel as they are now missing.

![sample](https://user-images.githubusercontent.com/19243508/197883575-5fe1f5e7-5beb-4e17-af61-c23fd61dbf04.png)

## How was this PR tested?

Tested on UE 5.0.3 as well as UE 4.27.2 that build works. Looked for regression by using side-to-side engines (might have missed some bits as I'm a newbie user)
